### PR TITLE
Enhance resolvers and organize all graphql apis given

### DIFF
--- a/migrations/20200127105045-Channel.js
+++ b/migrations/20200127105045-Channel.js
@@ -3,19 +3,19 @@
 module.exports = {
   up: (queryInterface, Sequelize) => {
    return queryInterface.addColumn(
-      'users',
-      'thumbURL',
+      'channels',
+      'name',
       {
         type: Sequelize.STRING,
-        before: "photoURL",
+        after: "type",
       },
     );
   },
 
   down: (queryInterface, Sequelize) => {
     return queryInterface.removeColumn(
-      'users',
-      'thumbURL',
+      'channels',
+      'name',
     );
   }
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "codecov": "codecov",
     "migrate:generate": "sequelize-cli migration:generate --name",
     "migrate:local": "cross-env NODE_ENV=local sequelize db:migrate",
+    "migrate:test": "cross-env NODE_ENV=test sequelize db:migrate",
     "migrate:dev": "cross-env NODE_ENV=development sequelize db:migrate",
     "migrate:prod": "cross-env NODE_ENV=production sequelize db:migrate",
     "migrate": "yarn migrate:dev && yarn migrate:prod"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate": "graphql-codegen --config codegen.yml",
     "codecov": "codecov",
     "migrate:generate": "sequelize-cli migration:generate --name",
+    "migrate:local": "cross-env NODE_ENV=local sequelize db:migrate",
     "migrate:dev": "cross-env NODE_ENV=development sequelize db:migrate",
     "migrate:prod": "cross-env NODE_ENV=production sequelize db:migrate",
     "migrate": "yarn migrate:dev && yarn migrate:prod"

--- a/schemas/channel.graphql
+++ b/schemas/channel.graphql
@@ -3,12 +3,24 @@
 
 scalar DateTime
 
+enum ChannelType {
+  PRIVATE,
+  PUBLIC
+}
+
 type Channel {
   id: ID!
-  type: String
+  type: ChannelType
+  name: String
   messages: [Message]
   membership: Membership
   createdAt: DateTime!
   updatedAt: DateTime!
   deletedAt: DateTime
+}
+
+input ChannelInput {
+  type: ChannelType
+  name: String
+  friendsId: [String!]!
 }

--- a/schemas/friend.graphql
+++ b/schemas/friend.graphql
@@ -1,5 +1,11 @@
 scalar DateTime
 
+enum FriendSubAction {
+  ADDED,
+  UPDATED,
+  DELETED,
+}
+
 type Friend {
   id: ID!
   user: User

--- a/schemas/friend.graphql
+++ b/schemas/friend.graphql
@@ -14,3 +14,8 @@ type Friend {
   updatedAt: DateTime
   deletedAt: DateTime
 }
+
+type FriendSub {
+  user: User
+  action: FriendSubAction
+}

--- a/schemas/notification.graphql
+++ b/schemas/notification.graphql
@@ -10,7 +10,6 @@ type Notification {
 }
 
 input NotificationCreateInput {
-  userId: ID!
   token: String!
   device: String
   os: String

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -35,5 +35,5 @@ type Mutation {
 type Subscription {
   userSignedIn: User
   userUpdated: User
-  friendsChanged(userId: ID! friend: User action: FriendSubAction): User
+  friendChanged(userId: ID!): FriendSub
 }

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -7,7 +7,7 @@
 # import Membership from "membership.graphql"
 
 type Query {
-  users(includeUser: Boolean): [User!]!
+  users(user: UserQueryInput, includeUser: Boolean): [User!]!
   user(id: ID!): User
   me: User
   findPassword(email: String!): Boolean

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -35,5 +35,5 @@ type Mutation {
 type Subscription {
   userSignedIn: User
   userUpdated: User
-  friendsChanged(userId: ID!): User
+  friendsChanged(userId: ID! friend: User action: FriendSubAction): User
 }

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -13,7 +13,7 @@ type Query {
   findPassword(email: String!): Boolean
   messages: [Message!]!
   channels: [Channel!]!
-  friends: [Friend!]!
+  friends: [User!]!
 }
 
 type Mutation {
@@ -23,9 +23,13 @@ type Mutation {
   signInApple(socialUser: SocialUserInput!): AuthPayload!
   signUp(user: UserInput!): AuthPayload!
   addNotificationToken(notification: NotificationCreateInput!): Notification
+  removeNotificationToken(token: String!): Int!
   updateProfile(user: UserInput!): User
   addFriend(friendId: ID!): User
   deleteFriend(friendId: ID!): User
+  createChannel(channel: ChannelInput): Channel
+  updateChannel(channel: ChannelInput): Int!
+  deleteChannel(channelId: ID!): Int!
 }
 
 type Subscription {

--- a/schemas/user.graphql
+++ b/schemas/user.graphql
@@ -51,6 +51,15 @@ input UserInput {
   statusMessage: String
 }
 
+input UserQueryInput {
+  email: String
+  name: String
+  nickname: String
+  birthday: Date
+  gender: Gender
+  phone: String
+}
+
 input SocialUserInput {
   socialId: String!
   authType: AuthType!

--- a/schemas/user.graphql
+++ b/schemas/user.graphql
@@ -33,8 +33,6 @@ type User {
   isOnline: Boolean
   lastSignedIn: DateTime
   notifications: [Notification]
-  channels: [Channel]
-  friends: [User]
   createdAt: DateTime
   updatedAt: DateTime
   deletedAt: DateTime

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,53 +1,11 @@
-import { Op, Sequelize } from 'sequelize';
-
+import { Sequelize } from 'sequelize';
 import config from '../../config/config';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const operatorsAliases = {
-  $eq: Op.eq,
-  $ne: Op.ne,
-  $gte: Op.gte,
-  $gt: Op.gt,
-  $lte: Op.lte,
-  $lt: Op.lt,
-  $not: Op.not,
-  $in: Op.in,
-  $notIn: Op.notIn,
-  $is: Op.is,
-  $like: Op.like,
-  $notLike: Op.notLike,
-  $iLike: Op.iLike,
-  $notILike: Op.notILike,
-  $regexp: Op.regexp,
-  $notRegexp: Op.notRegexp,
-  $iRegexp: Op.iRegexp,
-  $notIRegexp: Op.notIRegexp,
-  $between: Op.between,
-  $notBetween: Op.notBetween,
-  $overlap: Op.overlap,
-  $contains: Op.contains,
-  $contained: Op.contained,
-  $adjacent: Op.adjacent,
-  $strictLeft: Op.strictLeft,
-  $strictRight: Op.strictRight,
-  $noExtendRight: Op.noExtendRight,
-  $noExtendLeft: Op.noExtendLeft,
-  $and: Op.and,
-  $or: Op.or,
-  $any: Op.any,
-  $all: Op.all,
-  $values: Op.values,
-  $col: Op.col,
-};
 
 const sequelize = new Sequelize(
   config.database,
   config.username,
   config.password,
-  {
-    ...config,
-    operatorsAliases,
-  },
+  config,
 );
 
 if (process.env.NODE_ENV !== 'test') {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -44,7 +44,10 @@ const sequelize = new Sequelize(
   config.database,
   config.username,
   config.password,
-  config,
+  {
+    ...config,
+    operatorsAliases,
+  },
 );
 
 if (process.env.NODE_ENV !== 'test') {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -61,6 +61,12 @@ export type Friend = {
   deletedAt?: Maybe<Scalars['DateTime']>,
 };
 
+export enum FriendSubAction {
+  Added = 'ADDED',
+  Updated = 'UPDATED',
+  Deleted = 'DELETED'
+}
+
 export enum Gender {
   Male = 'MALE',
   Female = 'FEMALE'
@@ -259,7 +265,9 @@ export type Subscription = {
 
 
 export type SubscriptionFriendsChangedArgs = {
-  userId: Scalars['ID']
+  userId: Scalars['ID'],
+  friend?: Maybe<User>,
+  action?: Maybe<FriendSubAction>
 };
 
 export type User = {
@@ -408,6 +416,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']>,
   ChannelInput: ChannelInput,
   Subscription: ResolverTypeWrapper<{}>,
+  FriendSubAction: FriendSubAction,
   Friend: ResolverTypeWrapper<Friend>,
 };
 
@@ -439,6 +448,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int'],
   ChannelInput: ChannelInput,
   Subscription: {},
+  FriendSubAction: FriendSubAction,
   Friend: Friend,
 };
 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -175,6 +175,7 @@ export type Query = {
 
 
 export type QueryUsersArgs = {
+  user?: Maybe<UserQueryInput>,
   includeUser?: Maybe<Scalars['Boolean']>
 };
 
@@ -268,6 +269,15 @@ export enum UserModeType {
   Block = 'BLOCK'
 }
 
+export type UserQueryInput = {
+  email?: Maybe<Scalars['String']>,
+  name?: Maybe<Scalars['String']>,
+  nickname?: Maybe<Scalars['String']>,
+  birthday?: Maybe<Scalars['Date']>,
+  gender?: Maybe<Gender>,
+  phone?: Maybe<Scalars['String']>,
+};
+
 
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -340,12 +350,13 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>,
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
-  User: ResolverTypeWrapper<User>,
-  ID: ResolverTypeWrapper<Scalars['ID']>,
+  UserQueryInput: UserQueryInput,
   String: ResolverTypeWrapper<Scalars['String']>,
   Date: ResolverTypeWrapper<Scalars['Date']>,
   Gender: Gender,
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+  User: ResolverTypeWrapper<User>,
+  ID: ResolverTypeWrapper<Scalars['ID']>,
   AuthType: AuthType,
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>,
   Notification: ResolverTypeWrapper<Notification>,
@@ -367,12 +378,13 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Query: {},
-  Boolean: Scalars['Boolean'],
-  User: User,
-  ID: Scalars['ID'],
+  UserQueryInput: UserQueryInput,
   String: Scalars['String'],
   Date: Scalars['Date'],
   Gender: Gender,
+  Boolean: Scalars['Boolean'],
+  User: User,
+  ID: Scalars['ID'],
   AuthType: AuthType,
   DateTime: Scalars['DateTime'],
   Notification: Notification,

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -29,13 +29,25 @@ export enum AuthType {
 export type Channel = {
    __typename?: 'Channel',
   id: Scalars['ID'],
-  type?: Maybe<Scalars['String']>,
+  type?: Maybe<ChannelType>,
+  name?: Maybe<Scalars['String']>,
   messages?: Maybe<Array<Maybe<Message>>>,
   membership?: Maybe<Membership>,
   createdAt: Scalars['DateTime'],
   updatedAt: Scalars['DateTime'],
   deletedAt?: Maybe<Scalars['DateTime']>,
 };
+
+export type ChannelInput = {
+  type?: Maybe<ChannelType>,
+  name?: Maybe<Scalars['String']>,
+  friendsId: Array<Scalars['String']>,
+};
+
+export enum ChannelType {
+  Private = 'PRIVATE',
+  Public = 'PUBLIC'
+}
 
 
 
@@ -94,9 +106,13 @@ export type Mutation = {
   signInApple: AuthPayload,
   signUp: AuthPayload,
   addNotificationToken?: Maybe<Notification>,
+  removeNotificationToken: Scalars['Int'],
   updateProfile?: Maybe<User>,
   addFriend?: Maybe<User>,
   deleteFriend?: Maybe<User>,
+  createChannel?: Maybe<Channel>,
+  updateChannel: Scalars['Int'],
+  deleteChannel: Scalars['Int'],
 };
 
 
@@ -131,6 +147,11 @@ export type MutationAddNotificationTokenArgs = {
 };
 
 
+export type MutationRemoveNotificationTokenArgs = {
+  token: Scalars['String']
+};
+
+
 export type MutationUpdateProfileArgs = {
   user: UserInput
 };
@@ -145,6 +166,21 @@ export type MutationDeleteFriendArgs = {
   friendId: Scalars['ID']
 };
 
+
+export type MutationCreateChannelArgs = {
+  channel?: Maybe<ChannelInput>
+};
+
+
+export type MutationUpdateChannelArgs = {
+  channel?: Maybe<ChannelInput>
+};
+
+
+export type MutationDeleteChannelArgs = {
+  channelId: Scalars['ID']
+};
+
 export type Notification = {
    __typename?: 'Notification',
   id: Scalars['ID'],
@@ -156,7 +192,6 @@ export type Notification = {
 };
 
 export type NotificationCreateInput = {
-  userId: Scalars['ID'],
   token: Scalars['String'],
   device?: Maybe<Scalars['String']>,
   os?: Maybe<Scalars['String']>,
@@ -170,7 +205,7 @@ export type Query = {
   findPassword?: Maybe<Scalars['Boolean']>,
   messages: Array<Message>,
   channels: Array<Channel>,
-  friends: Array<Friend>,
+  friends: Array<User>,
 };
 
 
@@ -245,8 +280,6 @@ export type User = {
   isOnline?: Maybe<Scalars['Boolean']>,
   lastSignedIn?: Maybe<Scalars['DateTime']>,
   notifications?: Maybe<Array<Maybe<Notification>>>,
-  channels?: Maybe<Array<Maybe<Channel>>>,
-  friends?: Maybe<Array<Maybe<User>>>,
   createdAt?: Maybe<Scalars['DateTime']>,
   updatedAt?: Maybe<Scalars['DateTime']>,
   deletedAt?: Maybe<Scalars['DateTime']>,
@@ -360,19 +393,22 @@ export type ResolversTypes = {
   AuthType: AuthType,
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>,
   Notification: ResolverTypeWrapper<Notification>,
-  Channel: ResolverTypeWrapper<Channel>,
   Message: ResolverTypeWrapper<Message>,
-  Reply: ResolverTypeWrapper<Reply>,
+  Channel: ResolverTypeWrapper<Channel>,
+  ChannelType: ChannelType,
   Membership: ResolverTypeWrapper<Membership>,
   MemberType: MemberType,
   UserModeType: UserModeType,
-  Friend: ResolverTypeWrapper<Friend>,
+  Reply: ResolverTypeWrapper<Reply>,
   Mutation: ResolverTypeWrapper<{}>,
   AuthPayload: ResolverTypeWrapper<AuthPayload>,
   SocialUserInput: SocialUserInput,
   UserInput: UserInput,
   NotificationCreateInput: NotificationCreateInput,
+  Int: ResolverTypeWrapper<Scalars['Int']>,
+  ChannelInput: ChannelInput,
   Subscription: ResolverTypeWrapper<{}>,
+  Friend: ResolverTypeWrapper<Friend>,
 };
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -388,19 +424,22 @@ export type ResolversParentTypes = {
   AuthType: AuthType,
   DateTime: Scalars['DateTime'],
   Notification: Notification,
-  Channel: Channel,
   Message: Message,
-  Reply: Reply,
+  Channel: Channel,
+  ChannelType: ChannelType,
   Membership: Membership,
   MemberType: MemberType,
   UserModeType: UserModeType,
-  Friend: Friend,
+  Reply: Reply,
   Mutation: {},
   AuthPayload: AuthPayload,
   SocialUserInput: SocialUserInput,
   UserInput: UserInput,
   NotificationCreateInput: NotificationCreateInput,
+  Int: Scalars['Int'],
+  ChannelInput: ChannelInput,
   Subscription: {},
+  Friend: Friend,
 };
 
 export type AuthPayloadResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['AuthPayload'] = ResolversParentTypes['AuthPayload']> = {
@@ -410,7 +449,8 @@ export type AuthPayloadResolvers<ContextType = MyContext, ParentType extends Res
 
 export type ChannelResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Channel'] = ResolversParentTypes['Channel']> = {
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
-  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  type?: Resolver<Maybe<ResolversTypes['ChannelType']>, ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   messages?: Resolver<Maybe<Array<Maybe<ResolversTypes['Message']>>>, ParentType, ContextType>,
   membership?: Resolver<Maybe<ResolversTypes['Membership']>, ParentType, ContextType>,
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>,
@@ -467,9 +507,13 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   signInApple?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignInAppleArgs, 'socialUser'>>,
   signUp?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignUpArgs, 'user'>>,
   addNotificationToken?: Resolver<Maybe<ResolversTypes['Notification']>, ParentType, ContextType, RequireFields<MutationAddNotificationTokenArgs, 'notification'>>,
+  removeNotificationToken?: Resolver<ResolversTypes['Int'], ParentType, ContextType, RequireFields<MutationRemoveNotificationTokenArgs, 'token'>>,
   updateProfile?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateProfileArgs, 'user'>>,
   addFriend?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAddFriendArgs, 'friendId'>>,
   deleteFriend?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationDeleteFriendArgs, 'friendId'>>,
+  createChannel?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, MutationCreateChannelArgs>,
+  updateChannel?: Resolver<ResolversTypes['Int'], ParentType, ContextType, MutationUpdateChannelArgs>,
+  deleteChannel?: Resolver<ResolversTypes['Int'], ParentType, ContextType, RequireFields<MutationDeleteChannelArgs, 'channelId'>>,
 };
 
 export type NotificationResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Notification'] = ResolversParentTypes['Notification']> = {
@@ -488,7 +532,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   findPassword?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryFindPasswordArgs, 'email'>>,
   messages?: Resolver<Array<ResolversTypes['Message']>, ParentType, ContextType>,
   channels?: Resolver<Array<ResolversTypes['Channel']>, ParentType, ContextType>,
-  friends?: Resolver<Array<ResolversTypes['Friend']>, ParentType, ContextType>,
+  friends?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType>,
 };
 
 export type ReplyResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Reply'] = ResolversParentTypes['Reply']> = {
@@ -526,8 +570,6 @@ export type UserResolvers<ContextType = MyContext, ParentType extends ResolversP
   isOnline?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
   lastSignedIn?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
   notifications?: Resolver<Maybe<Array<Maybe<ResolversTypes['Notification']>>>, ParentType, ContextType>,
-  channels?: Resolver<Maybe<Array<Maybe<ResolversTypes['Channel']>>>, ParentType, ContextType>,
-  friends?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>,
   createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
   updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
   deletedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -61,6 +61,12 @@ export type Friend = {
   deletedAt?: Maybe<Scalars['DateTime']>,
 };
 
+export type FriendSub = {
+   __typename?: 'FriendSub',
+  user?: Maybe<User>,
+  action?: Maybe<FriendSubAction>,
+};
+
 export enum FriendSubAction {
   Added = 'ADDED',
   Updated = 'UPDATED',
@@ -260,14 +266,12 @@ export type Subscription = {
    __typename?: 'Subscription',
   userSignedIn?: Maybe<User>,
   userUpdated?: Maybe<User>,
-  friendsChanged?: Maybe<User>,
+  friendChanged?: Maybe<FriendSub>,
 };
 
 
-export type SubscriptionFriendsChangedArgs = {
-  userId: Scalars['ID'],
-  friend?: Maybe<User>,
-  action?: Maybe<FriendSubAction>
+export type SubscriptionFriendChangedArgs = {
+  userId: Scalars['ID']
 };
 
 export type User = {
@@ -416,6 +420,7 @@ export type ResolversTypes = {
   Int: ResolverTypeWrapper<Scalars['Int']>,
   ChannelInput: ChannelInput,
   Subscription: ResolverTypeWrapper<{}>,
+  FriendSub: ResolverTypeWrapper<FriendSub>,
   FriendSubAction: FriendSubAction,
   Friend: ResolverTypeWrapper<Friend>,
 };
@@ -448,6 +453,7 @@ export type ResolversParentTypes = {
   Int: Scalars['Int'],
   ChannelInput: ChannelInput,
   Subscription: {},
+  FriendSub: FriendSub,
   FriendSubAction: FriendSubAction,
   Friend: Friend,
 };
@@ -483,6 +489,11 @@ export type FriendResolvers<ContextType = MyContext, ParentType extends Resolver
   createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
   updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
   deletedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+};
+
+export type FriendSubResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['FriendSub'] = ResolversParentTypes['FriendSub']> = {
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
+  action?: Resolver<Maybe<ResolversTypes['FriendSubAction']>, ParentType, ContextType>,
 };
 
 export type MembershipResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Membership'] = ResolversParentTypes['Membership']> = {
@@ -560,7 +571,7 @@ export type ReplyResolvers<ContextType = MyContext, ParentType extends Resolvers
 export type SubscriptionResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
   userSignedIn?: SubscriptionResolver<Maybe<ResolversTypes['User']>, "userSignedIn", ParentType, ContextType>,
   userUpdated?: SubscriptionResolver<Maybe<ResolversTypes['User']>, "userUpdated", ParentType, ContextType>,
-  friendsChanged?: SubscriptionResolver<Maybe<ResolversTypes['User']>, "friendsChanged", ParentType, ContextType, RequireFields<SubscriptionFriendsChangedArgs, 'userId'>>,
+  friendChanged?: SubscriptionResolver<Maybe<ResolversTypes['FriendSub']>, "friendChanged", ParentType, ContextType, RequireFields<SubscriptionFriendChangedArgs, 'userId'>>,
 };
 
 export type UserResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
@@ -591,6 +602,7 @@ export type Resolvers<ContextType = MyContext> = {
   Date?: GraphQLScalarType,
   DateTime?: GraphQLScalarType,
   Friend?: FriendResolvers<ContextType>,
+  FriendSub?: FriendSubResolvers<ContextType>,
   Membership?: MembershipResolvers<ContextType>,
   Message?: MessageResolvers<ContextType>,
   Mutation?: MutationResolvers<ContextType>,

--- a/src/models/Channel.ts
+++ b/src/models/Channel.ts
@@ -2,15 +2,22 @@ import {
   BuildOptions,
   ENUM,
   Model,
+  STRING,
   UUID,
   UUIDV4,
 } from 'sequelize';
 
 import sequelize from '../db';
 
+export enum ChannelType {
+  Public = 'PUBLIC',
+  Private = 'PRIVATE'
+}
+
 class Channel extends Model {
   public id!: string;
-  public type!: string;
+  public type!: ChannelType;
+  public name: string;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
   public readonly deletedAt!: Date;
@@ -25,6 +32,10 @@ Channel.init({
   },
   type: {
     type: ENUM('PRIVATE', 'PUBLIC'),
+    defaultValue: ChannelType.Private,
+  },
+  name: {
+    type: STRING,
   },
 }, {
   sequelize,

--- a/src/resolvers/channel.ts
+++ b/src/resolvers/channel.ts
@@ -1,0 +1,58 @@
+import { Channel, Resolvers } from '../generated/graphql';
+
+import { AuthenticationError } from 'apollo-server-core';
+import { ChannelType } from '../models/Channel';
+import { Op } from 'sequelize';
+
+const resolver: Resolvers = {
+  Query: {
+    channels: async (_, args, { getUser, models }): Promise<Channel[]> => {
+      const auth = await getUser();
+
+      if (!auth) throw new AuthenticationError('User is not signed in');
+
+      const { Channel: channelModel, Membership: membershipModel } = models;
+
+      const memberships = await membershipModel.findAll({
+        where: { userId: auth.id },
+        raw: true,
+      });
+
+      const channelIds = [];
+      memberships.forEach((membership) => {
+        channelIds.push(membership.channelId);
+      });
+
+      const channels = await channelModel.findAll({
+        where: { id: { [Op.in]: channelIds } },
+        raw: true,
+      });
+
+      return channels;
+    },
+  },
+  Mutation: {
+    createChannel: async (_, args, { getUser, models }): Promise<Channel> => {
+      const auth = await getUser();
+
+      if (!auth) throw new AuthenticationError('User is not signed in');
+
+      const { Membership: membershipModel, Channel: channelModel } = models;
+      const { name, type, friendsId } = args.channel;
+
+      /**
+       * TODO
+       * 1. Check if there is a membership with only two users with `PRIVATE` type.
+       * 2. Create new channel
+       */
+      const channel = await channelModel.create({
+        name,
+        type,
+      });
+
+      return channel;
+    },
+  },
+};
+
+export default resolver;

--- a/src/resolvers/friend.ts
+++ b/src/resolvers/friend.ts
@@ -57,9 +57,8 @@ const resolver: Resolvers = {
         );
 
         pubsub.publish(FRIENDS_CHANGED, {
-          friendsChanged: {
-            userId: auth.id,
-            friend: user,
+          friendChanged: {
+            user,
             action: FriendSubAction.Added,
           },
         });
@@ -92,10 +91,9 @@ const resolver: Resolvers = {
         );
 
         pubsub.publish(FRIENDS_CHANGED, {
-          friendsChanged: {
-            userId: auth.id,
-            friend: user,
-            action: FriendSubAction.Added,
+          friendChanged: {
+            user,
+            action: FriendSubAction.Deleted,
           },
         });
         return user;
@@ -105,12 +103,12 @@ const resolver: Resolvers = {
     },
   },
   Subscription: {
-    friendsChanged: {
+    friendChanged: {
       subscribe: withFilter(
         (_, args, { pubsub }) => pubsub.asyncIterator(FRIENDS_CHANGED),
         (payload, { userId }) => {
-          const { friendsChanged } = payload;
-          return friendsChanged.userId === userId;
+          const { friendChanged } = payload;
+          return friendChanged.userId === userId;
         },
       ),
     },

--- a/src/resolvers/friend.ts
+++ b/src/resolvers/friend.ts
@@ -92,7 +92,11 @@ const resolver: Resolvers = {
         );
 
         pubsub.publish(FRIENDS_CHANGED, {
-          friendsChanged: auth,
+          friendsChanged: {
+            userId: auth.id,
+            friend: user,
+            action: FriendSubAction.Added,
+          },
         });
         return user;
       } catch (err) {

--- a/src/resolvers/friend.ts
+++ b/src/resolvers/friend.ts
@@ -1,4 +1,4 @@
-import { Resolvers, User } from '../generated/graphql';
+import { FriendSubAction, Resolvers, User } from '../generated/graphql';
 
 import { AuthenticationError } from 'apollo-server-core';
 import { Op } from 'sequelize';
@@ -57,7 +57,11 @@ const resolver: Resolvers = {
         );
 
         pubsub.publish(FRIENDS_CHANGED, {
-          friendsChanged: auth,
+          friendsChanged: {
+            userId: auth.id,
+            friend: user,
+            action: FriendSubAction.Added,
+          },
         });
         return user;
       } catch (err) {
@@ -102,7 +106,7 @@ const resolver: Resolvers = {
         (_, args, { pubsub }) => pubsub.asyncIterator(FRIENDS_CHANGED),
         (payload, { userId }) => {
           const { friendsChanged } = payload;
-          return friendsChanged.id === userId;
+          return friendsChanged.userId === userId;
         },
       ),
     },

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,3 +1,4 @@
+import Channel from './channel';
 import Chat from './message';
 import Friend from './friend';
 import Notification from './notification';
@@ -8,6 +9,7 @@ export const allResolvers = [
   Friend,
   Notification,
   User,
+  Channel,
 ];
 
 export default {
@@ -15,4 +17,5 @@ export default {
   Friend,
   Chat,
   Notification,
+  Channel,
 };

--- a/src/resolvers/notification.ts
+++ b/src/resolvers/notification.ts
@@ -1,16 +1,48 @@
 import { Notification, Resolvers } from '../generated/graphql';
 
+import { AuthenticationError } from 'apollo-server-core';
+
 const resolver: Resolvers = {
   Mutation: {
-    addNotificationToken: async (_, { notification }, { models }): Promise<Notification> => {
+    addNotificationToken: async (
+      _, { notification }, { models, getUser }): Promise<Notification> => {
       const { Notification: notificationModel } = models;
 
+      const auth = await getUser();
+
+      if (!auth) throw new AuthenticationError('User is not signed in');
+
+      const notificationArgs = {
+        ...notification,
+        userId: auth.id,
+      };
+
       try {
-        const created = await notificationModel.create(notification);
+        const created = await notificationModel.create(notificationArgs);
         return created;
       } catch (err) {
         throw new Error(err);
       }
+    },
+    removeNotificationToken: async (
+      _, { token }, { models, getUser }): Promise<number> => {
+      const { Notification: notificationModel } = models;
+
+      const auth = await getUser();
+
+      if (!auth) throw new AuthenticationError('User is not signed in');
+
+      try {
+        const deleted = await notificationModel.destroy({
+          where: {
+            userId: auth.id,
+            token,
+          },
+        });
+        return deleted;
+      } catch (err) {
+        throw new Error(err.message);
+      };
     },
   },
 };

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -1,6 +1,7 @@
 import {
   AuthPayload,
   Channel,
+  Friend,
   Notification,
   Resolvers,
   SocialUserInput,
@@ -249,27 +250,6 @@ your password will reset to <strong>dooboolab2017</strong>.
     },
   },
   User: {
-    channels: async (_, args, { models }): Promise<Channel[]> => {
-      const { id } = _;
-      const { Channel: channelModel, User: userModel } = models;
-
-      const channels = await channelModel.findAll({
-        where: {
-          $or: [{
-            ownerId: { $eq: id },
-            userId: { $eq: id },
-          }],
-        },
-        include: [
-          {
-            model: userModel,
-            as: 'owner',
-          },
-        ],
-      });
-
-      return channels;
-    },
     notifications: (_, args, { models }): Promise<Notification[]> => {
       const { id } = _;
       const { Notification: notificationModel } = models;

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -81,15 +81,20 @@ const resolver: Resolvers = {
 
       if (!auth) throw new AuthenticationError('User is not signed in');
 
-      if (args.includeUser) {
+      if (!args.includeUser) {
         return userModel.findAll({
           where: {
-            userId: { $ne: auth.id },
+            ...args.user,
+            id: {
+              $ne: auth.id,
+            },
           },
         });
       }
 
-      return userModel.findAll();
+      return userModel.findAll({
+        where: args.user,
+      });
     },
     user: (_, args, { models }): Promise<User> => {
       const { User } = models;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import models, { ModelType } from './models';
 
 import { ApolloServer } from 'apollo-server-express';
 import { Http2Server } from 'http2';
+import { Op } from 'sequelize';
 import { PubSub } from 'graphql-subscriptions';
 import SendGridMail from '@sendgrid/mail';
 import { User } from './models/User';


### PR DESCRIPTION
Organize all graphql apis given.
- Improve users query
- Properly add operatorsAliases for sequelize
- More implementations on notification and channel resolvers
- Update subscription senario for FriendSub