### PR TITLE
[enhancement][user] modify "updateProfile" resolver add "thumbURL", "photoURL" in UserProfileInput

### DIFF
--- a/migrations/20200222135717-User.js
+++ b/migrations/20200222135717-User.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.renameColumn('users', 'thumbUrl', 'thumbURL', { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.renameColumn('users', 'thumbURL', 'thumbUrl', { transaction });
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  }
+};

--- a/schemas/user.graphql
+++ b/schemas/user.graphql
@@ -55,6 +55,8 @@ input UserProfileInput {
   birthday: Date
   gender: Gender
   phone: String
+  thumbURL: String
+  photoURL: String
   statusMessage: String
 }
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -63,7 +63,7 @@ User.init({
   },
   name: STRING,
   nickname: STRING,
-  thumbUrl: STRING,
+  thumbURL: STRING,
   photoURL: STRING,
   birthday: {
     type: DATEONLY,

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -290,7 +290,7 @@ const resolver: Resolvers = {
         if (!auth) {
           throw ErrorUserNotSignedIn();
         }
-        models.User.update(
+        await models.User.update(
           args.user,
           {
             where: {

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,4 +1,5 @@
-import { request } from 'graphql-request';
+import { GraphQLClient, request } from 'graphql-request';
+
 import { testHost } from './testSetup';
 
 describe('Resolver - User', () => {
@@ -46,10 +47,73 @@ describe('Resolver - User', () => {
 
   it('should signIn email user', async () => {
     const response = await request(testHost, signInEmail);
-
     expect(response).toHaveProperty('signInEmail');
     expect(response.signInEmail).toHaveProperty('token');
     expect(response.signInEmail).toHaveProperty('user');
     expect(response.signInEmail.user.email).toEqual(email);
+  });
+
+  const updateProfile = /* GraphQL */`
+    mutation updateProfile($name: String!
+      $nickname: String
+      $birthday: Date
+      $phone: String
+      $gender: Gender
+      $thumbURL: String
+      $photoURL: String
+      $statusMessage: String
+    ) {
+      updateProfile(
+        user: {
+          name: $name
+          nickname: $nickname
+          birthday: $birthday
+          gender: $gender
+          phone: $phone
+          thumbURL: $thumbURL
+          photoURL: $photoURL
+          statusMessage: $statusMessage
+        }
+      ) {
+        id
+        email
+        name
+        nickname
+        birthday
+        gender
+        phone
+        thumbURL
+        photoURL
+        statusMessage
+        socialId
+        verified
+      }
+    }
+  `;
+
+  it('should user profile updated after user sign-in', async () => {
+    const signInRes = await request(testHost, signInEmail);
+
+    const client = new GraphQLClient(testHost, {
+      headers: {
+        authorization: `Bearer ${signInRes.signInEmail.token}`,
+      },
+    });
+    const variables = {
+      name: 'geoseong',
+      nickname: 'nick-geoseong',
+      birthday: '2020-02-22',
+      gender: 'MALE',
+      phone: '+82100000000',
+      thumbURL: 'https://avatars2.githubusercontent.com/u/19166187?s=88&v=4',
+      photoURL: 'https://avatars2.githubusercontent.com/u/19166187?s=460&v=4',
+      statusMessage: 'fighting',
+    };
+    const mutationRes = await client.request(updateProfile, variables);
+    expect(mutationRes).toHaveProperty('updateProfile');
+    for (const column in variables) {
+      expect(mutationRes.updateProfile).toHaveProperty(column);
+      expect(mutationRes.updateProfile[column]).toEqual(variables[column]);
+    }
   });
 });


### PR DESCRIPTION
## Description
- change column name from 'thumbUrl' to 'thumbURL' due to schema mismatch
- add `thumbURL` and `photoURL` prop in UserProfileInput
- add missing syntax `await` to sequelize's `update()` function

## Related Issues
resolve #57 

## Tests
- [x] should user profile updated after user sign-in

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run yarn lint && yarn tsc
- [x] I am willing to follow-up on review comments in a timely manner.