### PR TITLE
Remove virgilToken resolver and provider rest api

### DIFF
--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -16,7 +16,6 @@ type Query {
   users(user: UserQueryInput, includeUser: Boolean, filter: Boolean, first: Int, after: String): [User!]!
   user(id: ID!): User
   me: User
-  virgilToken: String!
   messages: [Message!]!
   channels: [Channel!]!
   friends: [User!]!

--- a/schemas/user.graphql
+++ b/schemas/user.graphql
@@ -32,7 +32,6 @@ type User {
   statusMessage: String
   isOnline: Boolean
   lastSignedIn: DateTime
-  virgilToken: String
   notifications: [Notification]
   createdAt: DateTime
   updatedAt: DateTime

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,13 @@
-import { encryptCredential, getToken, validateCredential } from './utils/auth';
+import {
+  encryptCredential,
+  getToken,
+  validateCredential,
+} from './utils/auth';
 import { resetPassword, verifyEmail } from './models/User';
 
 import FilesystemBackend from 'i18next-node-fs-backend';
 import cors from 'cors';
+import createOrGetVirgilJwtGenerator from './utils/virgil';
 import express from 'express';
 import fs from 'fs';
 import i18next from 'i18next';
@@ -128,6 +133,13 @@ export const createApp = (): express.Application => {
       }
     },
   );
+
+  app.get('/virgil-jwt/:identity', async (req: express.Request, res: express.Response) => {
+    const jwtGenerator = await createOrGetVirgilJwtGenerator();
+    // @ts-ignore
+    const jwt = jwtGenerator.generateToken(req.params.identity);
+    res.send(jwt.toString());
+  });
 
   app.get('/', (req, res) => {
     res.send(`${req.t('IT_WORKS')} - Version 0.0.1`);

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -275,7 +275,6 @@ export type Query = {
    * You can add pagination with first and after args.
  */
   users: Array<User>,
-  virgilToken: Scalars['String'],
 };
 
 
@@ -356,7 +355,6 @@ export type User = {
   thumbURL?: Maybe<Scalars['String']>,
   updatedAt?: Maybe<Scalars['DateTime']>,
   verified?: Maybe<Scalars['Boolean']>,
-  virgilToken?: Maybe<Scalars['String']>,
 };
 
 export type UserInput = {
@@ -668,7 +666,6 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   messages?: Resolver<Array<ResolversTypes['Message']>, ParentType, ContextType>,
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>,
   users?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType, QueryUsersArgs>,
-  virgilToken?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
 };
 
 export type ReplyResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Reply'] = ResolversParentTypes['Reply']> = {
@@ -710,7 +707,6 @@ export type UserResolvers<ContextType = MyContext, ParentType extends ResolversP
   thumbURL?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
   verified?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
-  virgilToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
   __isTypeOf?: isTypeOfResolverFn<ParentType>,
 };
 

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -82,15 +82,9 @@ const signInWithSocialAccount = async (
     appSecret,
   );
 
-  const generator = await createOrGetVirgilJwtGenerator();
-  const virgilJwtToken = generator.generateToken(user[0].id);
-
   return {
     token,
-    user: {
-      ...user[0],
-      virgilToken: virgilJwtToken.toString(),
-    },
+    user: user[0],
   };
 };
 
@@ -99,18 +93,6 @@ const resolver: Resolvers = {
     me: async (_, args, { getUser }): Promise<User> => {
       const auth = await getUser();
       return auth;
-    },
-    virgilToken: async (_, args, { verifyUser }): Promise<string> => {
-      const auth = verifyUser();
-      if (!auth) throw ErrorUserNotSignedIn();
-
-      try {
-        const generator = await createOrGetVirgilJwtGenerator();
-        const virgilJwtToken = generator.generateToken(auth.userId);
-        return virgilJwtToken.toString();
-      } catch (err) {
-        throw new Error(err);
-      }
     },
     users: async (_, args, { verifyUser, models }): Promise<User[]> => {
       const { User: userModel } = models;
@@ -210,16 +192,10 @@ const resolver: Resolvers = {
       );
 
       try {
-        const generator = await createOrGetVirgilJwtGenerator();
-        const virgilJwtToken = generator.generateToken(user.id);
-
         pubsub.publish(USER_SIGNED_IN, { userSignedIn: user });
         return {
           token,
-          user: {
-            ...user,
-            virgilToken: virgilJwtToken.toString(),
-          },
+          user,
         };
       } catch (err) {
         throw new Error(err);


### PR DESCRIPTION
Better to follow the guide to provider `restful api` and let it handle refresh token as `virgil` has designed.

Below is a referred talk:

<img width="413" alt="Screen Shot 2020-02-27 at 1 45 46 AM" src="https://user-images.githubusercontent.com/27461460/75366982-eda45d00-5902-11ea-928d-3d748db01bc0.png">