### PR TITLE
createMessage correctly finding existing channels correctly

### DIFF
--- a/src/models/Membership.ts
+++ b/src/models/Membership.ts
@@ -22,6 +22,7 @@ class Membership extends Model {
   public userId!: string;
   public type: MemberType;
   public alert: boolean;
+  public memberCnt?: number;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
   public readonly deletedAt!: Date;


### PR DESCRIPTION
Hotfix on `createMessage` resolver that did not retrieve correct `channelId` from `memberships` group.

I'd like to share my solution along with [trial](https://github.com/dooboolab/hackatalk-server/pull/64/files) given.

@smallbee3 How do you think about my solution?