### PR TITLE
Find existing channels correctly in 'createMessage' mutation(2)

### DIFF
--- a/src/models/Channel.ts
+++ b/src/models/Channel.ts
@@ -20,6 +20,7 @@ class Channel extends Model {
   public id!: string;
   public type!: ChannelType;
   public name: string;
+  public numOfMemberships?: number;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
   public readonly deletedAt!: Date;

--- a/src/models/Membership.ts
+++ b/src/models/Membership.ts
@@ -22,7 +22,6 @@ class Membership extends Model {
   public userId!: string;
   public type: MemberType;
   public alert: boolean;
-  public memberCnt?: number;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
   public readonly deletedAt!: Date;

--- a/src/resolvers/message.ts
+++ b/src/resolvers/message.ts
@@ -39,7 +39,7 @@ const resolver: Resolvers = {
           };
         }
 
-        const authUsers = [...users, auth.userId];
+        const authUsers = [...new Set([...users, auth.userId])];
         const channels = await channelModel.findAll({
           group: ['channelId'],
           having: sequelize.where(

--- a/src/resolvers/message.ts
+++ b/src/resolvers/message.ts
@@ -55,6 +55,7 @@ const resolver: Resolvers = {
             WHERE c.deletedAt IS NULL
             GROUP BY c.id
             HAVING COUNT(c.id) = :authUserNum
+            ORDER BY c.updatedAt DESC
           `,
         {
           replacements: { authUsers: authUsers, authUserNum: authUsers.length },


### PR DESCRIPTION
## Description
This pull request is to solve the issue of pull request #66. 

## Key points
- Remove duplicates in 'authUsers' array
- Allow self-talk (creating own message) only when Input one's own userId into mutation argument

## Related Pullrequest
#66 

## CheckList
- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run yarn lint && yarn tsc
- [x] I am willing to follow-up on review comments in a timely manner.