### PR TITLE
Refactor createChannel and createMessage

### DIFF
--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -58,6 +58,9 @@ type Mutation {
   updateProfile(user: UserProfileInput!): User
   addFriend(friendId: ID!): User
   deleteFriend(friendId: ID!): User
+  """
+  `friendIds` in Channel should exclude userid.
+  """
   createChannel(channel: ChannelInput): Channel
   updateChannel(channel: ChannelInput): Int
   deleteChannel(channelId: ID!): Int
@@ -65,7 +68,7 @@ type Mutation {
   Create message and return channelId when meessage has successfully sent.
   Do not pass current userId inside `users`.
   """
-  createMessage(users: [String!]! message: String! channelId: String): MessagePayload
+  createMessage(message: String! channelId: String!): MessagePayload
   setOnlineStatus(isOnline: Boolean): Int
   changeEmailPassword(password: String! newPassword: String!): Boolean
   createGallery(photoURL: String!): Gallery

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -4,20 +4,20 @@ export type Maybe<T> = T | null;
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string,
-  String: string,
-  Boolean: boolean,
-  Int: number,
-  Float: number,
-  DateTime: any,
-  Date: any,
-  Upload: any,
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  DateTime: any;
+  Date: any;
+  Upload: any;
 };
 
 export type AuthPayload = {
-   __typename?: 'AuthPayload',
-  token: Scalars['String'],
-  user: User,
+   __typename?: 'AuthPayload';
+  token: Scalars['String'];
+  user: User;
 };
 
 export enum AuthType {
@@ -28,22 +28,22 @@ export enum AuthType {
 }
 
 export type Channel = {
-   __typename?: 'Channel',
-  createdAt: Scalars['DateTime'],
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  id: Scalars['ID'],
-  memberships?: Maybe<Array<Maybe<Membership>>>,
-  messages?: Maybe<Array<Maybe<Message>>>,
-  myMembership?: Maybe<Membership>,
-  name?: Maybe<Scalars['String']>,
-  type?: Maybe<ChannelType>,
-  updatedAt: Scalars['DateTime'],
+   __typename?: 'Channel';
+  createdAt: Scalars['DateTime'];
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['ID'];
+  memberships?: Maybe<Array<Maybe<Membership>>>;
+  messages?: Maybe<Array<Maybe<Message>>>;
+  myMembership?: Maybe<Membership>;
+  name?: Maybe<Scalars['String']>;
+  type?: Maybe<ChannelType>;
+  updatedAt: Scalars['DateTime'];
 };
 
 export type ChannelInput = {
-  type?: Maybe<ChannelType>,
-  name?: Maybe<Scalars['String']>,
-  friendIds: Array<Scalars['String']>,
+  type?: Maybe<ChannelType>;
+  name?: Maybe<Scalars['String']>;
+  friendIds: Array<Scalars['String']>;
 };
 
 export enum ChannelType {
@@ -54,26 +54,26 @@ export enum ChannelType {
 
 
 export type File = {
-   __typename?: 'File',
-  encoding: Scalars['String'],
-  filename: Scalars['String'],
-  mimetype: Scalars['String'],
+   __typename?: 'File';
+  encoding: Scalars['String'];
+  filename: Scalars['String'];
+  mimetype: Scalars['String'];
 };
 
 export type Friend = {
-   __typename?: 'Friend',
-  createdAt?: Maybe<Scalars['DateTime']>,
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  friend?: Maybe<User>,
-  id: Scalars['ID'],
-  updatedAt?: Maybe<Scalars['DateTime']>,
-  user?: Maybe<User>,
+   __typename?: 'Friend';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  friend?: Maybe<User>;
+  id: Scalars['ID'];
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  user?: Maybe<User>;
 };
 
 export type FriendSub = {
-   __typename?: 'FriendSub',
-  user?: Maybe<User>,
-  action?: Maybe<FriendSubAction>,
+   __typename?: 'FriendSub';
+  user?: Maybe<User>;
+  action?: Maybe<FriendSubAction>;
 };
 
 export enum FriendSubAction {
@@ -83,12 +83,12 @@ export enum FriendSubAction {
 }
 
 export type Gallery = {
-   __typename?: 'Gallery',
-  createdAt: Scalars['DateTime'],
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  id: Scalars['ID'],
-  photoURL: Scalars['String'],
-  updatedAt: Scalars['DateTime'],
+   __typename?: 'Gallery';
+  createdAt: Scalars['DateTime'];
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['ID'];
+  photoURL: Scalars['String'];
+  updatedAt: Scalars['DateTime'];
 };
 
 export enum Gender {
@@ -97,16 +97,16 @@ export enum Gender {
 }
 
 export type Membership = {
-   __typename?: 'Membership',
-  channel?: Maybe<Channel>,
-  createdAt?: Maybe<Scalars['DateTime']>,
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  id: Scalars['ID'],
-  type?: Maybe<MemberType>,
-  updatedAt?: Maybe<Scalars['DateTime']>,
-  user?: Maybe<User>,
-  userAlert?: Maybe<Scalars['Boolean']>,
-  userMode?: Maybe<UserModeType>,
+   __typename?: 'Membership';
+  channel?: Maybe<Channel>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['ID'];
+  type?: Maybe<MemberType>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  user?: Maybe<User>;
+  userAlert?: Maybe<Scalars['Boolean']>;
+  userMode?: Maybe<UserModeType>;
 };
 
 export enum MemberType {
@@ -115,310 +115,308 @@ export enum MemberType {
 }
 
 export type Message = {
-   __typename?: 'Message',
-  channel?: Maybe<Channel>,
-  createdAt?: Maybe<Scalars['DateTime']>,
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  filePath?: Maybe<Scalars['String']>,
-  id: Scalars['String'],
-  picture?: Maybe<Array<Maybe<Photo>>>,
-  replies?: Maybe<Array<Maybe<Reply>>>,
-  sender?: Maybe<User>,
-  text?: Maybe<Scalars['String']>,
-  type?: Maybe<Scalars['String']>,
-  updatedAt?: Maybe<Scalars['DateTime']>,
+   __typename?: 'Message';
+  channel?: Maybe<Channel>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  filePath?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  picture?: Maybe<Array<Maybe<Photo>>>;
+  replies?: Maybe<Array<Maybe<Reply>>>;
+  sender?: Maybe<User>;
+  text?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type MessagePayload = {
-   __typename?: 'MessagePayload',
-  channelId: Scalars['String'],
-  message?: Maybe<Message>,
+   __typename?: 'MessagePayload';
+  channelId: Scalars['String'];
+  message?: Maybe<Message>;
 };
 
 export type Mutation = {
-   __typename?: 'Mutation',
-  addFriend?: Maybe<User>,
-  addNotificationToken?: Maybe<Notification>,
-  changeEmailPassword?: Maybe<Scalars['Boolean']>,
-  createChannel?: Maybe<Channel>,
-  createGallery?: Maybe<Gallery>,
+   __typename?: 'Mutation';
+  addFriend?: Maybe<User>;
+  addNotificationToken?: Maybe<Notification>;
+  changeEmailPassword?: Maybe<Scalars['Boolean']>;
+  /** `friendIds` in Channel should exclude userid. */
+  createChannel?: Maybe<Channel>;
+  createGallery?: Maybe<Gallery>;
   /** 
  * Create message and return channelId when meessage has successfully sent.
    * Do not pass current userId inside `users`.
  */
-  createMessage?: Maybe<MessagePayload>,
-  deleteChannel?: Maybe<Scalars['Int']>,
-  deleteFriend?: Maybe<User>,
-  deleteGallery?: Maybe<Scalars['Int']>,
-  findPassword?: Maybe<Scalars['Boolean']>,
-  removeNotificationToken?: Maybe<Scalars['Int']>,
-  sendVerification?: Maybe<Scalars['Boolean']>,
-  setOnlineStatus?: Maybe<Scalars['Int']>,
-  signInEmail: AuthPayload,
-  signInWithSocialAccount: AuthPayload,
-  signUp: AuthPayload,
-  singleUpload: Scalars['String'],
-  updateChannel?: Maybe<Scalars['Int']>,
-  updateGallery?: Maybe<Scalars['Int']>,
-  updateProfile?: Maybe<User>,
+  createMessage?: Maybe<MessagePayload>;
+  deleteChannel?: Maybe<Scalars['Int']>;
+  deleteFriend?: Maybe<User>;
+  deleteGallery?: Maybe<Scalars['Int']>;
+  findPassword?: Maybe<Scalars['Boolean']>;
+  removeNotificationToken?: Maybe<Scalars['Int']>;
+  sendVerification?: Maybe<Scalars['Boolean']>;
+  setOnlineStatus?: Maybe<Scalars['Int']>;
+  signInEmail: AuthPayload;
+  signInWithSocialAccount: AuthPayload;
+  signUp: AuthPayload;
+  singleUpload: Scalars['String'];
+  updateChannel?: Maybe<Scalars['Int']>;
+  updateGallery?: Maybe<Scalars['Int']>;
+  updateProfile?: Maybe<User>;
 };
 
 
 export type MutationAddFriendArgs = {
-  friendId: Scalars['ID']
+  friendId: Scalars['ID'];
 };
 
 
 export type MutationAddNotificationTokenArgs = {
-  notification: NotificationCreateInput
+  notification: NotificationCreateInput;
 };
 
 
 export type MutationChangeEmailPasswordArgs = {
-  password: Scalars['String'],
-  newPassword: Scalars['String']
+  password: Scalars['String'];
+  newPassword: Scalars['String'];
 };
 
 
 export type MutationCreateChannelArgs = {
-  channel?: Maybe<ChannelInput>
+  channel?: Maybe<ChannelInput>;
 };
 
 
 export type MutationCreateGalleryArgs = {
-  photoURL: Scalars['String']
+  photoURL: Scalars['String'];
 };
 
 
 export type MutationCreateMessageArgs = {
-  users: Array<Scalars['String']>,
-  message: Scalars['String'],
-  channelId?: Maybe<Scalars['String']>
+  message: Scalars['String'];
+  channelId: Scalars['String'];
 };
 
 
 export type MutationDeleteChannelArgs = {
-  channelId: Scalars['ID']
+  channelId: Scalars['ID'];
 };
 
 
 export type MutationDeleteFriendArgs = {
-  friendId: Scalars['ID']
+  friendId: Scalars['ID'];
 };
 
 
 export type MutationDeleteGalleryArgs = {
-  galleryId: Scalars['ID']
+  galleryId: Scalars['ID'];
 };
 
 
 export type MutationFindPasswordArgs = {
-  email: Scalars['String']
+  email: Scalars['String'];
 };
 
 
 export type MutationRemoveNotificationTokenArgs = {
-  token: Scalars['String']
+  token: Scalars['String'];
 };
 
 
 export type MutationSendVerificationArgs = {
-  email: Scalars['String']
+  email: Scalars['String'];
 };
 
 
 export type MutationSetOnlineStatusArgs = {
-  isOnline?: Maybe<Scalars['Boolean']>
+  isOnline?: Maybe<Scalars['Boolean']>;
 };
 
 
 export type MutationSignInEmailArgs = {
-  email: Scalars['String'],
-  password: Scalars['String']
+  email: Scalars['String'];
+  password: Scalars['String'];
 };
 
 
 export type MutationSignInWithSocialAccountArgs = {
-  socialUser: SocialUserInput
+  socialUser: SocialUserInput;
 };
 
 
 export type MutationSignUpArgs = {
-  user: UserInput
+  user: UserInput;
 };
 
 
 export type MutationSingleUploadArgs = {
-  file: Scalars['Upload'],
-  dir?: Maybe<Scalars['String']>
+  file: Scalars['Upload'];
+  dir?: Maybe<Scalars['String']>;
 };
 
 
 export type MutationUpdateChannelArgs = {
-  channel?: Maybe<ChannelInput>
+  channel?: Maybe<ChannelInput>;
 };
 
 
 export type MutationUpdateGalleryArgs = {
-  galleryId: Scalars['ID'],
-  photoURL: Scalars['String']
+  galleryId: Scalars['ID'];
+  photoURL: Scalars['String'];
 };
 
 
 export type MutationUpdateProfileArgs = {
-  user: UserProfileInput
+  user: UserProfileInput;
 };
 
 export type Notification = {
-   __typename?: 'Notification',
-  createdAt?: Maybe<Scalars['DateTime']>,
-  device?: Maybe<Scalars['String']>,
-  id: Scalars['ID'],
-  os?: Maybe<Scalars['String']>,
-  token?: Maybe<Scalars['String']>,
-  updatedAt?: Maybe<Scalars['DateTime']>,
+   __typename?: 'Notification';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  device?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  os?: Maybe<Scalars['String']>;
+  token?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type NotificationCreateInput = {
-  token: Scalars['String'],
-  device?: Maybe<Scalars['String']>,
-  os?: Maybe<Scalars['String']>,
+  token: Scalars['String'];
+  device?: Maybe<Scalars['String']>;
+  os?: Maybe<Scalars['String']>;
 };
 
 /** Information about pagination in a connection. */
 export type PageInfo = {
-   __typename?: 'PageInfo',
-  startCursor?: Maybe<Scalars['String']>,
-  endCursor?: Maybe<Scalars['String']>,
-  hasNextPage?: Maybe<Scalars['Boolean']>,
-  hasPreviousPage?: Maybe<Scalars['Boolean']>,
+   __typename?: 'PageInfo';
+  startCursor?: Maybe<Scalars['String']>;
+  endCursor?: Maybe<Scalars['String']>;
+  hasNextPage?: Maybe<Scalars['Boolean']>;
+  hasPreviousPage?: Maybe<Scalars['Boolean']>;
 };
 
 export type Photo = {
-   __typename?: 'Photo',
-  createdAt?: Maybe<Scalars['DateTime']>,
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  id: Scalars['String'],
-  photoURL?: Maybe<Scalars['String']>,
-  thumbURL?: Maybe<Scalars['String']>,
-  updatedAt?: Maybe<Scalars['DateTime']>,
+   __typename?: 'Photo';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  id: Scalars['String'];
+  photoURL?: Maybe<Scalars['String']>;
+  thumbURL?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type Query = {
-   __typename?: 'Query',
-  channels: Array<Channel>,
-  friends: Array<User>,
-  galleries: Array<Gallery>,
-  me?: Maybe<User>,
-  messages: Array<Message>,
-  user?: Maybe<User>,
+   __typename?: 'Query';
+  channels: Array<Channel>;
+  friends: Array<User>;
+  galleries: Array<Gallery>;
+  me?: Maybe<User>;
+  messages: Array<Message>;
+  user?: Maybe<User>;
   /** 
  * If filter is true, it will filter user with email, nickname or name.
    * You can add pagination with first and after args.
  */
-  users?: Maybe<UsersConnection>,
+  users?: Maybe<UsersConnection>;
 };
 
 
 export type QueryGalleriesArgs = {
-  userId: Scalars['String']
+  userId: Scalars['String'];
 };
 
 
 export type QueryUserArgs = {
-  id: Scalars['ID']
+  id: Scalars['ID'];
 };
 
 
 export type QueryUsersArgs = {
-  user?: Maybe<UserQueryInput>,
-  includeUser?: Maybe<Scalars['Boolean']>,
-  filter?: Maybe<Scalars['Boolean']>,
-  first?: Maybe<Scalars['Int']>,
-  last?: Maybe<Scalars['Int']>,
-  before?: Maybe<Scalars['String']>,
-  after?: Maybe<Scalars['String']>
+  user?: Maybe<UserQueryInput>;
+  includeUser?: Maybe<Scalars['Boolean']>;
+  filter?: Maybe<Scalars['Boolean']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['String']>;
+  after?: Maybe<Scalars['String']>;
 };
 
 export type Reply = {
-   __typename?: 'Reply',
-  createdAt?: Maybe<Scalars['DateTime']>,
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  filePath?: Maybe<Scalars['String']>,
-  id: Scalars['String'],
-  replies?: Maybe<Array<Maybe<Reply>>>,
-  sender?: Maybe<User>,
-  text?: Maybe<Scalars['String']>,
-  type?: Maybe<Scalars['String']>,
-  updatedAt?: Maybe<Scalars['DateTime']>,
+   __typename?: 'Reply';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  filePath?: Maybe<Scalars['String']>;
+  id: Scalars['String'];
+  replies?: Maybe<Array<Maybe<Reply>>>;
+  sender?: Maybe<User>;
+  text?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
 };
 
 export type SocialUserInput = {
-  socialId: Scalars['String'],
-  authType: AuthType,
-  email?: Maybe<Scalars['String']>,
-  photoURL?: Maybe<Scalars['String']>,
-  thumbURL?: Maybe<Scalars['String']>,
-  name?: Maybe<Scalars['String']>,
-  nickname?: Maybe<Scalars['String']>,
-  birthday?: Maybe<Scalars['Date']>,
-  gender?: Maybe<Gender>,
-  phone?: Maybe<Scalars['String']>,
+  socialId: Scalars['String'];
+  authType: AuthType;
+  email?: Maybe<Scalars['String']>;
+  photoURL?: Maybe<Scalars['String']>;
+  thumbURL?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  nickname?: Maybe<Scalars['String']>;
+  birthday?: Maybe<Scalars['Date']>;
+  gender?: Maybe<Gender>;
+  phone?: Maybe<Scalars['String']>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription',
-  friendChanged?: Maybe<FriendSub>,
-  userSignedIn?: Maybe<User>,
-  userUpdated?: Maybe<User>,
+   __typename?: 'Subscription';
+  friendChanged?: Maybe<FriendSub>;
+  userSignedIn?: Maybe<User>;
+  userUpdated?: Maybe<User>;
 };
 
 
 export type SubscriptionFriendChangedArgs = {
-  userId: Scalars['ID']
+  userId: Scalars['ID'];
 };
 
 
 export type User = {
-   __typename?: 'User',
-  authType?: Maybe<AuthType>,
-  birthday?: Maybe<Scalars['Date']>,
-  createdAt?: Maybe<Scalars['DateTime']>,
-  deletedAt?: Maybe<Scalars['DateTime']>,
-  email?: Maybe<Scalars['String']>,
-  gender?: Maybe<Gender>,
-  id: Scalars['ID'],
-  isOnline?: Maybe<Scalars['Boolean']>,
-  lastSignedIn?: Maybe<Scalars['DateTime']>,
-  name?: Maybe<Scalars['String']>,
-  nickname?: Maybe<Scalars['String']>,
-  notifications?: Maybe<Array<Maybe<Notification>>>,
-  phone?: Maybe<Scalars['String']>,
-  photoURL?: Maybe<Scalars['String']>,
-  socialId?: Maybe<Scalars['String']>,
-  statusMessage?: Maybe<Scalars['String']>,
-  thumbURL?: Maybe<Scalars['String']>,
-  updatedAt?: Maybe<Scalars['DateTime']>,
-  verified?: Maybe<Scalars['Boolean']>,
+   __typename?: 'User';
+  authType?: Maybe<AuthType>;
+  birthday?: Maybe<Scalars['Date']>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  email?: Maybe<Scalars['String']>;
+  gender?: Maybe<Gender>;
+  id: Scalars['ID'];
+  isOnline?: Maybe<Scalars['Boolean']>;
+  lastSignedIn?: Maybe<Scalars['DateTime']>;
+  name?: Maybe<Scalars['String']>;
+  nickname?: Maybe<Scalars['String']>;
+  notifications?: Maybe<Array<Maybe<Notification>>>;
+  phone?: Maybe<Scalars['String']>;
+  photoURL?: Maybe<Scalars['String']>;
+  socialId?: Maybe<Scalars['String']>;
+  statusMessage?: Maybe<Scalars['String']>;
+  thumbURL?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  verified?: Maybe<Scalars['Boolean']>;
 };
 
 export type UserEdge = {
-   __typename?: 'UserEdge',
-  node?: Maybe<User>,
-  cursor?: Maybe<Scalars['String']>,
+   __typename?: 'UserEdge';
+  node?: Maybe<User>;
+  cursor?: Maybe<Scalars['String']>;
 };
 
 export type UserInput = {
-  email: Scalars['String'],
-  password: Scalars['String'],
-  name?: Maybe<Scalars['String']>,
-  nickname?: Maybe<Scalars['String']>,
-  birthday?: Maybe<Scalars['Date']>,
-  gender?: Maybe<Gender>,
-  phone?: Maybe<Scalars['String']>,
-  thumbURL?: Maybe<Scalars['String']>,
-  photoURL?: Maybe<Scalars['String']>,
-  statusMessage?: Maybe<Scalars['String']>,
+  email: Scalars['String'];
+  password: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  nickname?: Maybe<Scalars['String']>;
+  birthday?: Maybe<Scalars['Date']>;
+  gender?: Maybe<Gender>;
+  phone?: Maybe<Scalars['String']>;
+  statusMessage?: Maybe<Scalars['String']>;
 };
 
 export enum UserModeType {
@@ -428,21 +426,23 @@ export enum UserModeType {
 }
 
 export type UserProfileInput = {
-  name?: Maybe<Scalars['String']>,
-  nickname?: Maybe<Scalars['String']>,
-  birthday?: Maybe<Scalars['Date']>,
-  gender?: Maybe<Gender>,
-  phone?: Maybe<Scalars['String']>,
-  statusMessage?: Maybe<Scalars['String']>,
+  name?: Maybe<Scalars['String']>;
+  nickname?: Maybe<Scalars['String']>;
+  birthday?: Maybe<Scalars['Date']>;
+  gender?: Maybe<Gender>;
+  phone?: Maybe<Scalars['String']>;
+  thumbURL?: Maybe<Scalars['String']>;
+  photoURL?: Maybe<Scalars['String']>;
+  statusMessage?: Maybe<Scalars['String']>;
 };
 
 export type UserQueryInput = {
-  email?: Maybe<Scalars['String']>,
-  name?: Maybe<Scalars['String']>,
-  nickname?: Maybe<Scalars['String']>,
-  birthday?: Maybe<Scalars['Date']>,
-  gender?: Maybe<Gender>,
-  phone?: Maybe<Scalars['String']>,
+  email?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  nickname?: Maybe<Scalars['String']>;
+  birthday?: Maybe<Scalars['Date']>;
+  gender?: Maybe<Gender>;
+  phone?: Maybe<Scalars['String']>;
 };
 
 /** 
@@ -451,22 +451,15 @@ export type UserQueryInput = {
  * after these.
  */
 export type UsersConnection = {
-   __typename?: 'UsersConnection',
-  totalCount?: Maybe<Scalars['Int']>,
-  edges?: Maybe<Array<Maybe<UserEdge>>>,
-  pageInfo?: Maybe<PageInfo>,
+   __typename?: 'UsersConnection';
+  totalCount?: Maybe<Scalars['Int']>;
+  edges?: Maybe<Array<Maybe<UserEdge>>>;
+  pageInfo?: Maybe<PageInfo>;
 };
 
 
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
-
-export type ResolverFn<TResult, TParent, TContext, TArgs> = (
-  parent: TParent,
-  args: TArgs,
-  context: TContext,
-  info: GraphQLResolveInfo
-) => Promise<TResult> | TResult;
 
 
 export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
@@ -477,6 +470,13 @@ export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -514,9 +514,9 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes>;
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type isTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean;
+export type isTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
@@ -709,21 +709,21 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   addFriend?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationAddFriendArgs, 'friendId'>>,
   addNotificationToken?: Resolver<Maybe<ResolversTypes['Notification']>, ParentType, ContextType, RequireFields<MutationAddNotificationTokenArgs, 'notification'>>,
   changeEmailPassword?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationChangeEmailPasswordArgs, 'password' | 'newPassword'>>,
-  createChannel?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, MutationCreateChannelArgs>,
+  createChannel?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, RequireFields<MutationCreateChannelArgs, never>>,
   createGallery?: Resolver<Maybe<ResolversTypes['Gallery']>, ParentType, ContextType, RequireFields<MutationCreateGalleryArgs, 'photoURL'>>,
-  createMessage?: Resolver<Maybe<ResolversTypes['MessagePayload']>, ParentType, ContextType, RequireFields<MutationCreateMessageArgs, 'users' | 'message'>>,
+  createMessage?: Resolver<Maybe<ResolversTypes['MessagePayload']>, ParentType, ContextType, RequireFields<MutationCreateMessageArgs, 'message' | 'channelId'>>,
   deleteChannel?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationDeleteChannelArgs, 'channelId'>>,
   deleteFriend?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationDeleteFriendArgs, 'friendId'>>,
   deleteGallery?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationDeleteGalleryArgs, 'galleryId'>>,
   findPassword?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationFindPasswordArgs, 'email'>>,
   removeNotificationToken?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationRemoveNotificationTokenArgs, 'token'>>,
   sendVerification?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationSendVerificationArgs, 'email'>>,
-  setOnlineStatus?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, MutationSetOnlineStatusArgs>,
+  setOnlineStatus?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationSetOnlineStatusArgs, never>>,
   signInEmail?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignInEmailArgs, 'email' | 'password'>>,
   signInWithSocialAccount?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignInWithSocialAccountArgs, 'socialUser'>>,
   signUp?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignUpArgs, 'user'>>,
   singleUpload?: Resolver<ResolversTypes['String'], ParentType, ContextType, RequireFields<MutationSingleUploadArgs, 'file'>>,
-  updateChannel?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, MutationUpdateChannelArgs>,
+  updateChannel?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationUpdateChannelArgs, never>>,
   updateGallery?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationUpdateGalleryArgs, 'galleryId' | 'photoURL'>>,
   updateProfile?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationUpdateProfileArgs, 'user'>>,
 };
@@ -763,7 +763,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
   messages?: Resolver<Array<ResolversTypes['Message']>, ParentType, ContextType>,
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>,
-  users?: Resolver<Maybe<ResolversTypes['UsersConnection']>, ParentType, ContextType, QueryUsersArgs>,
+  users?: Resolver<Maybe<ResolversTypes['UsersConnection']>, ParentType, ContextType, RequireFields<QueryUsersArgs, never>>,
 };
 
 export type ReplyResolvers<ContextType = MyContext, ParentType extends ResolversParentTypes['Reply'] = ResolversParentTypes['Reply']> = {

--- a/src/resolvers/message.ts
+++ b/src/resolvers/message.ts
@@ -1,22 +1,17 @@
 import { Message, MessagePayload, Resolvers } from '../generated/graphql';
 
-import { ChannelType } from '../models/Channel';
-import { ErrorString } from '../../src/utils/error';
 import { MessageType } from '../models/Message';
+import { Op } from 'sequelize';
 import { checkAuth } from '../utils/auth';
 
 const resolver: Resolvers = {
   Mutation: {
     createMessage: async (_, args, { verifyUser, models }): Promise<MessagePayload> => {
-      const { users, message, channelId } = args;
+      const { message, channelId } = args;
       const {
         Message: messageModel,
-        Channel: channelModel,
         Membership: membershipModel,
       } = models;
-
-      if (!args.message) throw ErrorString.MesssageIsEmpty;
-      if (!args.users || args.users.length === 0) throw ErrorString.UsersAreEmpty;
 
       const auth = verifyUser();
       checkAuth(auth);
@@ -31,56 +26,25 @@ const resolver: Resolvers = {
           });
         };
 
-        if (channelId) {
-          return {
-            channelId,
-            message: await addMessage(channelId),
-          };
-        }
-
-        const authUsers = [...users, auth.userId];
-        const channel = await channelModel.findOne({
-          include: [
-            {
-              model: membershipModel,
-              as: 'memberships',
-              where: {
-                userId: authUsers,
-              },
-              attributes: [
-                'channelId', 'userId',
-              ],
-            },
+        /**
+         * Used to find users to send push notifications
+         */
+        const members = await membershipModel.findAll({
+          attributes: [
+            'userId',
           ],
+          where: {
+            channelId,
+            userId: {
+              [Op.ne]: auth.userId,
+            },
+          },
+          raw: true,
         });
 
-        let retrievedChannelId = channel?.getDataValue('id') || undefined;
-
-        if (!retrievedChannelId) {
-          const channel = await channelModel.create(
-            {
-              type: ChannelType.Private,
-              name: '',
-            },
-          );
-
-          retrievedChannelId = channel.getDataValue('id');
-
-          const membershipPromises = [];
-
-          authUsers.forEach((user, index) => {
-            membershipPromises[index++] = membershipModel.create({
-              channelId: retrievedChannelId,
-              userId: user,
-            });
-          });
-
-          await Promise.all(membershipPromises);
-        }
-
         return {
-          channelId: retrievedChannelId,
-          message: await addMessage(retrievedChannelId),
+          channelId,
+          message: await addMessage(channelId),
         };
       } catch (err) {
         throw new Error(err);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -11,10 +11,7 @@ export enum ErrorString {
   EmailForUserExists = 'Email for current user is already signed up.',
   EmailSentFailed = 'Email sent failed',
   EmailNotValid = 'Not a valid email address',
-  FriendIdsRequired = 'FriendIds are required',
   UrlNotValid = 'Url is not a valid url. It should start with http.',
-  MesssageIsEmpty = 'Message is empty',
-  UsersAreEmpty = 'Users are empty',
   FirstLastNotSupported = 'Passing both `first` and `last` is not supported.',
 }
 
@@ -38,10 +35,6 @@ export const ErrorEmailSentFailed =
 export const ErrorEmailNotValid =
   (): ValidationError =>
     new ValidationError(ErrorString.EmailNotValid);
-
-export const ErrorFriendIdRequired =
-  (): UserInputError =>
-    new UserInputError(ErrorString.FriendIdsRequired);
 
 export const ErrorUrlNotValid =
   (): ValidationError =>


### PR DESCRIPTION
* Refactor `createChannel` and `createMessage` resolvers.
* New channel will be created only when `members` of chat is greater than 2 (auth user is counted).
* Closes #69 