### PR TITLE
Apply Facebook social login validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     # machine: true
     docker:
-      - image: circleci/node:11
+      - image: circleci/node:12
       - image: mysql:5.7
         command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb-large-prefix=true --innodb-file-format=Barracuda
         environment:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'no-console': 'error',
     'max-len': ['error', { code: 100 }],
     'comma-dangle': ['error', 'always-multiline'],
+    '@typescript-eslint/camelcase': 0,
     semi: [2, 'always'],
     'arrow-parens': ['error', 'always'],
     'space-before-function-paren': ['error', 'never'],

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "migrate": "yarn migrate:test && yarn migrate:dev && yarn migrate:prod"
   },
   "dependencies": {
-    "@sendgrid/mail": "^7.1.0",
-    "apollo-server": "^2.13.0",
-    "apollo-server-express": "^2.13.0",
+    "@sendgrid/mail": "^6.5.4",
+    "apollo-server": "^2.11.0",
+    "apollo-server-express": "^2.11.0",
+    "axios": "^0.19.2",
     "azure-storage": "^2.10.3",
     "bcrypt-nodejs": "^0.0.3",
     "cors": "^2.8.5",

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -50,6 +50,7 @@ type Query {
 type Mutation {
   signInEmail(email: String! password: String!): AuthPayload!
   signInWithSocialAccount(socialUser: SocialUserInput!): AuthPayload!
+  signInWithFacebook(accessToken: String!): AuthPayload!
   signUp(user: UserInput!): AuthPayload!
   findPassword(email: String!): Boolean
   sendVerification(email: String!): Boolean

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -166,6 +166,7 @@ export type Mutation = {
   sendVerification?: Maybe<Scalars['Boolean']>;
   setOnlineStatus?: Maybe<Scalars['Int']>;
   signInEmail: AuthPayload;
+  signInWithFacebook: AuthPayload;
   signInWithSocialAccount: AuthPayload;
   signUp: AuthPayload;
   singleUpload: Scalars['String'];
@@ -256,6 +257,11 @@ export type MutationSetOnlineStatusArgs = {
 export type MutationSignInEmailArgs = {
   email: Scalars['String'];
   password: Scalars['String'];
+};
+
+
+export type MutationSignInWithFacebookArgs = {
+  accessToken: Scalars['String'];
 };
 
 
@@ -764,6 +770,7 @@ export type MutationResolvers<ContextType = MyContext, ParentType extends Resolv
   sendVerification?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationSendVerificationArgs, 'email'>>,
   setOnlineStatus?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, RequireFields<MutationSetOnlineStatusArgs, never>>,
   signInEmail?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignInEmailArgs, 'email' | 'password'>>,
+  signInWithFacebook?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignInWithFacebookArgs, 'accessToken'>>,
   signInWithSocialAccount?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignInWithSocialAccountArgs, 'socialUser'>>,
   signUp?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationSignUpArgs, 'user'>>,
   singleUpload?: Resolver<ResolversTypes['String'], ParentType, ContextType, RequireFields<MutationSingleUploadArgs, 'file'>>,


### PR DESCRIPTION
# WHY
Currently, we don't validate for social login so it's possible to log in with random `userId`.
<img width="932" alt="스크린샷 2020-05-09 오후 12 12 45" src="https://user-images.githubusercontent.com/22088158/81462736-a6cebf80-91ef-11ea-98e2-91bd86367d20.png">

# HOW
To fix this problem I added validation logic for Facebook social login. 

1. Get access token from the client.

2. Check whether it is a validated access token created our client App.
 In this process, we need to `FACEBOOK_APP_ID`, `FACEBOOK_APP_SECRET_CODE` that is used client App to create access code.

3. If it's not a valid return error.
<img width="1124" alt="스크린샷 2020-05-09 오후 12 38 29" src="https://user-images.githubusercontent.com/22088158/81463121-0af28300-91f2-11ea-80a9-f480b0052f58.png">


# TEST
To test this feature you need `FACEBOOK_APP_ID`, `FACEBOOK_APP_SECRET_CODE`.
It's saved `.env` file
```
# Facebook
FACEBOOK_APP_ID=123456789
FACEBOOK_APP_SECRET_CODE=123456789
```
I referred to @JongtaekChoi 's article to make Facebook App.
https://medium.com/react-native-seoul/react-native-expo%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-facebook-sign-in-%ED%95%98%EA%B8%B0-2a72ac6af517

# Checklist
- [x]  I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x]  I signed the [CLA].
- [x]  Run yarn lint.
- [x]  Run yarn test.
- [x]  I am willing to follow-up on review comments in a timely manner.
