### PR TITLE
Fix the 404 ERROR when hash value contain '/'(%2F)

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -21,6 +21,7 @@ export const encryptCredential = async (password: string): Promise<string> =>
       if (err) {
         return reject(err);
       }
+      hash = hash.replace(/\//g, 'slash');
       resolve(hash);
     });
   });
@@ -29,6 +30,7 @@ export const validateCredential = async (
   value: string,
   hashedValue: string,
 ): Promise<boolean> => new Promise<boolean>((resolve, reject) => {
+  hashedValue = hashedValue.replace(/slash/g, '/');
   bcrypt.compare(value, hashedValue, (err, res) => {
     if (err) {
       return reject(err);


### PR DESCRIPTION
## WHY

- To fix the bug of 404 ERROR when the hash value contains slash value.

( Detail explanation of the issue )
In hackatalk-sever project, we've used bcrypt as a password-hashing function.
Since bcrypt uses base64 encoding internally, slash(/) can be included in the hash value as '%2F'.
When user requests email verification, the server sends a link to user's email. And user send a GET request to the server by clicking the link. The problem occurs when the link contains '%2F', encoded value of slash, as the GET request URL now looks like 

## HOW

Replace '/' with 'slash' in encryptCredential function. And then turn 'slash' back to '/' in validateCredential function.

## TEST PLAN

If the test code is required for this PR, please leave me a comment.


## Checklist

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test`.
- [x] I am willing to follow-up on review comments in a timely manner.
