### PR TITLE
Refactor eslint & prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pm2": "cross-env NODE_ENV=local pm2 start ts-node -- -P tsconfig.json ./src/server.ts --node-args='--local' --watch",
     "pm2:prod": "cross-env pm2 start ts-node -- -P tsconfig.json ./src/server.ts --node-args='--production'",
     "watch": "nodemon --watch 'src/**/*.ts' --ignore 'src/**/*.spec.ts' --exec 'ts-node' src/index.ts",
-    "lint": "eslint src/**/**/*.ts && eslint tests/**/**/*.ts",
+    "lint": "eslint src/**/**/*.ts tests/**/**/*.ts",
     "tsc": "tsc",
     "test": "NODE_ENV=test jest --runInBand --detectOpenHandles",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "nodemon": "^2.0.4",
     "pm2": "^4.4.0",
+    "prettier": "^2.0.5",
     "sequelize-cli": "^5.5.1",
     "ts-jest": "^26.1.0",
     "ts-node": "^8.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9184,6 +9184,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"


### PR DESCRIPTION
## WHY

a. **prettier** haven't added to devDependencies

b. The command `yarn lint --fix` doesn't fix the lint error under `src` folder (/**/*.ts).
This is because `--fix` option only applies to `eslint tests/**/**/*.ts`, which is the half of whole `yarn lint` command.
<br />


## HOW

a. Install prettier as devDependency
b. Add `eslint-fix` command to scripts of package.json
<br />


## Reference

https://stackoverflow.com/questions/51265476/fix-doesnt-fix-the-errors-using-eslint
<br />


## Checklist

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test`.
- [x] I am willing to follow-up on review comments in a timely manner.
