### PR TITLE
Change auth enum types

### DIFF
--- a/migrations/20200215073023-User.js
+++ b/migrations/20200215073023-User.js
@@ -54,7 +54,7 @@ module.exports = {
         socialId: {
           type: STRING,
         },
-        authType: ENUM('EMAIL', 'FACEBOOK', 'GOOGLE', 'APPLE'),
+        authType: ENUM('email', 'facebook', 'google', 'apple'),
         verified: {
           type: BOOLEAN,
           defaultValue: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "hackatalk-server",
-  "version": "0.0.1",
   "description": "Hackatalk Server",
   "main": "src/server.ts",
   "repository": "https://github.com/dooboolab/hackatalk-server",

--- a/schemas/user.graphql
+++ b/schemas/user.graphql
@@ -11,10 +11,10 @@ enum Gender {
 }
 
 enum AuthType {
-  EMAIL,
-  FACEBOOK,
-  GOOGLE,
-  APPLE
+  email,
+  facebook,
+  google,
+  apple
 }
 
 type User {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 
 import { MyContext } from '../context';
+
 export type Maybe<T> = T | null;
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
@@ -22,10 +23,10 @@ export type AuthPayload = {
 };
 
 export enum AuthType {
-  Email = 'EMAIL',
-  Facebook = 'FACEBOOK',
-  Google = 'GOOGLE',
-  Apple = 'APPLE'
+  Email = 'email',
+  Facebook = 'facebook',
+  Google = 'google',
+  Apple = 'apple'
 }
 
 export type Channel = {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -25,10 +25,10 @@ export enum Gender {
 }
 
 export enum AuthType {
-  Email = 'EMAIL',
-  Facebook = 'FACEBOOK',
-  Google = 'GOOGLE',
-  Apple = 'APPLE',
+  Email = 'email',
+  Facebook = 'facebook',
+  Google = 'google',
+  Apple = 'apple',
 }
 
 export class User extends Model {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -76,7 +76,7 @@ User.init({
   gender: ENUM('MALE', 'FEMALE'),
   phone: STRING,
   socialId: STRING,
-  authType: ENUM('EMAIL', 'FACEBOOK', 'GOOGLE', 'APPLE'),
+  authType: ENUM('email', 'facebook', 'google', 'apple'),
   verified: {
     type: BOOLEAN,
     defaultValue: false,


### PR DESCRIPTION
## WHY

Server auth types are not identical to the client which is [expo](expo.io).

## HOW

Change enum types values to lowercases as in expo client.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test`.
- [x] I am willing to follow-up on review comments in a timely manner.
